### PR TITLE
Feat: Improve contracts initialization and remove unnecesary approve

### DIFF
--- a/src/ChatterPay.sol
+++ b/src/ChatterPay.sol
@@ -172,6 +172,10 @@ contract ChatterPay is
         _;
     }
 
+    /**
+     * @dev Disables initialization for the implementation contract
+     */
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();

--- a/src/ChatterPay.sol
+++ b/src/ChatterPay.sol
@@ -171,11 +171,9 @@ contract ChatterPay is
     /**
      * @dev Constructor that disables initialization for the implementation contract
      */
-    /*
     constructor() {
         _disableInitializers();
     }
-    */
 
     /*//////////////////////////////////////////////////////////////
                             INITIALIZATION
@@ -420,8 +418,6 @@ contract ChatterPay is
         uint256 swapAmount = amountIn - fee;
 
         // Swap setup
-        IERC20(tokenIn).approve(address(s_state.swapRouter), swapAmount);
-
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
             tokenIn: tokenIn,
             tokenOut: tokenOut,


### PR DESCRIPTION
## Changelog

1. Uncommented _disableInitializers() in constructor
This ensures that the implementation contract itself cannot be initialized. This is a critical security measure for upgradeable contracts.

The custom annotation @ custom:oz-upgrades-unsafe-allow constructor tells the OpenZeppelin Upgrades plugin to bypass validation on this constructor. Normally, having any constructor logic in upgradeable contracts would trigger warnings, but this specific pattern is allowed as a security measure. (See reference in OZ docs)

2. Added _Context_init() and __UUPSUpgradeable_init_unchained()
These additions ensure proper initialization of parent contracts. When working with upgradeable contracts, you need to manually call the initializers of all parent contracts, unlike with regular contracts where Solidity automatically calls parent constructors.

3. Removed unnecessary approval on swap function
This change removes redundant token approval in `executeSwap()` function as the approval is being handled in the backend before the executeSwap call.

## Resources:
OZ Docs: https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable#initializing_the_implementation_contract

## New deployed contracts

### ChatterPayPaymaster: 
0x2ffE811D4b53735f03B6Bd26c07685341c6616A4

### ChatterPay:
Implementation: 0x6f3b380e91e595247A4745Cbe5B5f54FD5C0B8dF
Proxy: 0x3b4fA9e069bc0933705Fe4F791a98e102d50a9ac

### ChatterPayWalletFactory: 
0x5BFc792117998FBD2E28015c113Fc48e111f42B7

### ChatterPayNFT:
Implementation: 0x1cA1468cF006096367d0227cC8Ac6F5FfBE8BA93
Proxy: 0x96A39FA18017aDe33756E0fE83742DaB18D7b297

### ChatterPayVault:
0xDbC3E8282605a623d707DF5963361884adD0Da11

### Updated mongo object
```diff
{
  "entryPoint": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+  "factoryAddress": "0x5BFc792117998FBD2E28015c113Fc48e111f42B7",
+  "chatterPayAddress": "0x3b4fA9e069bc0933705Fe4F791a98e102d50a9ac",
+  "chatterNFTAddress": "0x96A39FA18017aDe33756E0fE83742DaB18D7b297",
+  "paymasterAddress": "0x2ffE811D4b53735f03B6Bd26c07685341c6616A4",
 "routerAddress": "0x101F443B4d1b059569D643917553c771E1b9663E"
}
```

-----

## Closed

- #86 