### PR TITLE
Fix: paymaster validation

### DIFF
--- a/src/ChatterPay.sol
+++ b/src/ChatterPay.sol
@@ -178,7 +178,7 @@ contract ChatterPay is
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
-        _disableInitializers();
+        // To-Fix: _disableInitializers();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/ChatterPayPaymaster.sol
+++ b/src/ChatterPayPaymaster.sol
@@ -7,7 +7,6 @@ import {IEntryPoint} from "lib/entry-point-v6/interfaces/IEntryPoint.sol";
 error ChatterPayPaymaster__OnlyOwner();
 error ChatterPayPaymaster__OnlyEntryPoint();
 error ChatterPayPaymaster__InvalidDataLength();
-error ChatterPayPaymaster__SignatureExpired();
 error ChatterPayPaymaster__InvalidSignature();
 error ChatterPayPaymaster__InvalidChainId();
 error ChatterPayPaymaster__InvalidVValue();
@@ -22,10 +21,13 @@ error ChatterPayPaymaster__ExecutionFailed();
  */
 contract ChatterPayPaymaster is IPaymaster {
     address public owner;
-    // address public entryPoint;
     IEntryPoint public entryPoint;
     address private backendSigner;
     uint256 private immutable chainId;
+
+    // Offset constants
+    uint256 private constant SIGNATURE_OFFSET = 20;
+    uint256 private constant EXPIRATION_OFFSET = 85;
 
     /**
      * @notice Ensures that only the contract owner can call the function
@@ -58,13 +60,12 @@ contract ChatterPayPaymaster is IPaymaster {
 
     /**
      * @notice Validates a UserOperation for the Paymaster
-     * @dev Ensures the operation is properly signed and not expired
+     * @dev Ensures the operation is properly signed and returns validationData with expiration time
      * @param userOp The UserOperation struct containing operation details
      * @return context Additional context for the operation (empty in this case)
-     * @return validationData A value indicating the validation status (0 = valid)
+     * @return validationData A packed value containing validation status and expiration time
      * @custom:error ChatterPayPaymaster__OnlyEntryPoint if caller is not EntryPoint
      * @custom:error ChatterPayPaymaster__InvalidDataLength if paymasterAndData is malformed
-     * @custom:error ChatterPayPaymaster__SignatureExpired if signature expiration is reached
      * @custom:error ChatterPayPaymaster__InvalidSignature if signature is invalid
      * @custom:error ChatterPayPaymaster__InvalidChainId if chain ID doesn't match
      */
@@ -87,12 +88,12 @@ contract ChatterPayPaymaster is IPaymaster {
             revert ChatterPayPaymaster__InvalidDataLength();
 
         // Extract components
-        bytes memory signature = _slice(paymasterAndData, 20, 65);
-        uint64 expiration = uint64(bytes8(_slice(paymasterAndData, 85, 8)));
+        bytes memory signature = _slice(paymasterAndData, SIGNATURE_OFFSET, 65);
+        uint64 expiration = uint64(
+            bytes8(_slice(paymasterAndData, EXPIRATION_OFFSET, 8))
+        );
 
-        // Validate expiration and chain
-        if (block.timestamp > expiration)
-            revert ChatterPayPaymaster__SignatureExpired();
+        // Validate chain ID - this is allowed in validation
         if (block.chainid != chainId)
             revert ChatterPayPaymaster__InvalidChainId();
 
@@ -108,10 +109,30 @@ contract ChatterPayPaymaster is IPaymaster {
         );
 
         address recoveredAddress = _recoverSigner(messageHash, signature);
-        if (recoveredAddress != backendSigner)
-            revert ChatterPayPaymaster__InvalidSignature();
+        bool sigFailed = recoveredAddress != backendSigner;
 
-        return ("", 0);
+        if (sigFailed) revert ChatterPayPaymaster__InvalidSignature();
+
+        // Pack validation data with expiration time instead of checking block.timestamp
+        // validAfter = 0 (can be executed immediately)
+        // validUntil = expiration timestamp
+        return ("", _packValidationData(false, expiration, 0));
+    }
+
+    /**
+     * @notice Packs validation data according to EIP-4337 format
+     * @dev Combines signature validation, validUntil and validAfter into a single uint256
+     * @param sigFailed Whether the signature validation failed
+     * @param validUntil The timestamp until which the operation is valid
+     * @param validAfter The timestamp after which the operation is valid
+     * @return A packed uint256 containing all validation data
+     */
+    function _packValidationData(
+        bool sigFailed,
+        uint256 validUntil,
+        uint256 validAfter
+    ) internal pure returns (uint256) {
+        return (sigFailed ? 1 : 0) | (validUntil << 160) | (validAfter << 192);
     }
 
     /**
@@ -164,8 +185,11 @@ contract ChatterPayPaymaster is IPaymaster {
      * @param withdrawAddress the address to send withdrawn value.
      * @param withdrawAmount the amount to withdraw.
      */
-    function withdrawTo(address payable withdrawAddress, uint256 withdrawAmount) external {
-         entryPoint.withdrawTo(withdrawAddress, withdrawAmount);
+    function withdrawTo(
+        address payable withdrawAddress,
+        uint256 withdrawAmount
+    ) external onlyOwner {
+        entryPoint.withdrawTo(withdrawAddress, withdrawAmount);
     }
 
     /**

--- a/src/ChatterPayPaymaster.sol
+++ b/src/ChatterPayPaymaster.sol
@@ -72,51 +72,59 @@ contract ChatterPayPaymaster is IPaymaster {
         UserOperation calldata userOp,
         bytes32,
         uint256
-    ) external view override returns (bytes memory context, uint256 validationData) {
+    )
+        external
+        view
+        override
+        returns (bytes memory context, uint256 validationData)
+    {
         _requireFromEntryPoint();
-        /*
+
         bytes memory paymasterAndData = userOp.paymasterAndData;
 
-        // Validate data length
-        if (paymasterAndData.length != 93) revert ChatterPayPaymaster__InvalidDataLength();
+        // Validate data length - expecting 93 bytes (20 + 65 + 8)
+        if (paymasterAndData.length != 93)
+            revert ChatterPayPaymaster__InvalidDataLength();
 
         // Extract components
         bytes memory signature = _slice(paymasterAndData, 20, 65);
         uint64 expiration = uint64(bytes8(_slice(paymasterAndData, 85, 8)));
 
         // Validate expiration and chain
-        if (block.timestamp > expiration) revert ChatterPayPaymaster__SignatureExpired();
-        if (block.chainid != chainId) revert ChatterPayPaymaster__InvalidChainId();
+        if (block.timestamp > expiration)
+            revert ChatterPayPaymaster__SignatureExpired();
+        if (block.chainid != chainId)
+            revert ChatterPayPaymaster__InvalidChainId();
 
-        // Validate signature
+        // Validate signature - MUST match backend's hash calculation exactly
         bytes32 messageHash = keccak256(
             abi.encode(
                 userOp.sender,
                 expiration,
-                chainId,
-                entryPoint,
+                uint256(chainId),
+                address(entryPoint),
                 userOp.callData
             )
         );
 
         address recoveredAddress = _recoverSigner(messageHash, signature);
-        if (recoveredAddress != backendSigner) revert ChatterPayPaymaster__InvalidSignature();
-        */
+        if (recoveredAddress != backendSigner)
+            revert ChatterPayPaymaster__InvalidSignature();
+
         return ("", 0);
     }
 
     /**
-    * @notice Implements the postOp function required by IPaymaster.
-    * @dev This function is marked as view since it only verifies that the caller is the EntryPoint.
-    */
+     * @notice Implements the postOp function required by IPaymaster.
+     * @dev This function is marked as view since it only verifies that the caller is the EntryPoint.
+     */
     function postOp(
-        PostOpMode,         // Unused parameter
-        bytes calldata,     // Unused parameter
-        uint256             // Unused parameter
+        PostOpMode, // Unused parameter
+        bytes calldata, // Unused parameter
+        uint256 // Unused parameter
     ) external view override {
         _requireFromEntryPoint();
     }
-
 
     /**
      * Add stake for this paymaster.
@@ -184,7 +192,8 @@ contract ChatterPayPaymaster is IPaymaster {
      * @custom:error ChatterPayPaymaster__OnlyEntryPoint if caller is not EntryPoint
      */
     function _requireFromEntryPoint() internal view {
-        if (msg.sender != address(entryPoint)) revert ChatterPayPaymaster__OnlyEntryPoint();
+        if (msg.sender != address(entryPoint))
+            revert ChatterPayPaymaster__OnlyEntryPoint();
     }
 
     /**
@@ -201,7 +210,8 @@ contract ChatterPayPaymaster is IPaymaster {
         uint256 start,
         uint256 length
     ) internal pure returns (bytes memory) {
-        if (data.length < start + length) revert ChatterPayPaymaster__SliceOutOfBounds();
+        if (data.length < start + length)
+            revert ChatterPayPaymaster__SliceOutOfBounds();
         bytes memory result = new bytes(length);
         for (uint256 i = 0; i < length; i++) {
             result[i] = data[start + i];
@@ -222,7 +232,8 @@ contract ChatterPayPaymaster is IPaymaster {
         bytes32 messageHash,
         bytes memory signature
     ) internal pure returns (address) {
-        if (signature.length != 65) revert ChatterPayPaymaster__InvalidSignatureLength();
+        if (signature.length != 65)
+            revert ChatterPayPaymaster__InvalidSignatureLength();
         bytes32 r;
         bytes32 s;
         uint8 v;

--- a/test/modules/PaymasterModule.t.sol
+++ b/test/modules/PaymasterModule.t.sol
@@ -3,15 +3,9 @@ pragma solidity ^0.8.24;
 
 import {Test, console} from "forge-std/Test.sol";
 import {BaseTest} from "../setup/BaseTest.sol";
-import {
-    ChatterPayPaymaster,
-    ChatterPayPaymaster__SignatureExpired,
-    ChatterPayPaymaster__InvalidSignature,
-    ChatterPayPaymaster__OnlyOwner,
-    ChatterPayPaymaster__InvalidDataLength
-} from "../../src/ChatterPayPaymaster.sol";
+import {ChatterPayPaymaster, ChatterPayPaymaster__SignatureExpired, ChatterPayPaymaster__InvalidSignature, ChatterPayPaymaster__OnlyOwner, ChatterPayPaymaster__InvalidDataLength} from "../../src/ChatterPayPaymaster.sol";
 import {UserOperation} from "lib/entry-point-v6/interfaces/IAccount.sol";
-import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 /**
  * @title PaymasterTest
@@ -21,10 +15,10 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 contract PaymasterTest is BaseTest {
     /// @notice Instance of the paymaster contract being tested
     ChatterPayPaymaster public paymasterInstance;
-    
+
     /// @notice Backend signer's private key for testing
     uint256 private backendSignerKey;
-    
+
     /// @notice Backend signer's address
     address private backendSigner;
 
@@ -34,12 +28,12 @@ contract PaymasterTest is BaseTest {
     /// @notice Sets up the test environment
     function setUp() public override {
         super.setUp();
-        
+
         // Setup backend signer
         backendSignerKey = 0x12345; // Test private key
         backendSigner = vm.addr(backendSignerKey);
         testWallet = makeAddr("testWallet");
-        
+
         // Deploy paymaster with test configuration
         vm.startPrank(owner);
         paymasterInstance = new ChatterPayPaymaster(ENTRY_POINT, backendSigner);
@@ -52,10 +46,12 @@ contract PaymasterTest is BaseTest {
      * @dev Verifies that a valid signature and unexpired timestamp pass validation
      */
     function testValidPaymasterUserOp() public {
-        vm.skip(true); // Skip until fix validatePaymasterUserOp
+        // Remove skip now that validatePaymasterUserOp is fixed
+        // vm.skip(true);
+
         // Create test UserOperation
         UserOperation memory userOp = _createBasicUserOp();
-        
+
         // Generate paymaster data with valid signature
         uint64 expiration = uint64(block.timestamp + 3600); // 1 hour from now
         bytes memory paymasterData = _generatePaymasterData(
@@ -69,11 +65,8 @@ contract PaymasterTest is BaseTest {
 
         // Validate through EntryPoint
         vm.prank(ENTRY_POINT);
-        (bytes memory context, uint256 validationData) = paymasterInstance.validatePaymasterUserOp(
-            userOp,
-            bytes32(0),
-            0
-        );
+        (bytes memory context, uint256 validationData) = paymasterInstance
+            .validatePaymasterUserOp(userOp, bytes32(0), 0);
 
         // Assert validation succeeded
         assertEq(validationData, 0, "Validation should succeed");
@@ -85,9 +78,11 @@ contract PaymasterTest is BaseTest {
      * @dev Verifies that an expired timestamp causes validation to fail
      */
     function testExpiredSignature() public {
-        vm.skip(true); // Skip until fix validatePaymasterUserOp
+        // Remove skip now that validatePaymasterUserOp is fixed
+        // vm.skip(true);
+
         UserOperation memory userOp = _createBasicUserOp();
-        
+
         // Generate paymaster data with expired timestamp
         uint64 expiration = uint64(block.timestamp - 1); // Expired
         bytes memory paymasterData = _generatePaymasterData(
@@ -110,9 +105,11 @@ contract PaymasterTest is BaseTest {
      * @dev Verifies that an incorrectly signed operation is rejected
      */
     function testInvalidSignature() public {
-        vm.skip(true); // Skip until fix validatePaymasterUserOp
+        // Remove skip now that validatePaymasterUserOp is fixed
+        // vm.skip(true);
+
         UserOperation memory userOp = _createBasicUserOp();
-        
+
         // Generate paymaster data with wrong signer
         uint64 expiration = uint64(block.timestamp + 3600);
         uint256 wrongKey = 0x9999; // Different private key
@@ -138,18 +135,22 @@ contract PaymasterTest is BaseTest {
     function testWithdraw() public {
         uint256 initialBalance = 1 ether;
         vm.deal(address(paymasterInstance), initialBalance);
-        
+
         // Test non-owner withdrawal (should fail)
         vm.prank(user);
         vm.expectRevert(ChatterPayPaymaster__OnlyOwner.selector);
         paymasterInstance.withdraw();
-        
+
         // Test owner withdrawal (should succeed)
         uint256 ownerInitialBalance = owner.balance;
         vm.prank(owner);
         paymasterInstance.withdraw();
-        
-        assertEq(address(paymasterInstance).balance, 0, "Paymaster should have 0 balance");
+
+        assertEq(
+            address(paymasterInstance).balance,
+            0,
+            "Paymaster should have 0 balance"
+        );
         assertEq(
             owner.balance,
             ownerInitialBalance + initialBalance,
@@ -165,32 +166,58 @@ contract PaymasterTest is BaseTest {
         address destination = makeAddr("destination");
         bytes memory data = "";
         uint256 value = 0.1 ether;
-        
+
         // Fund paymaster
         vm.deal(address(paymasterInstance), 1 ether);
-        
+
         // Test non-owner execute (should fail)
         vm.prank(user);
         vm.expectRevert(ChatterPayPaymaster__OnlyOwner.selector);
         paymasterInstance.execute(destination, value, data);
-        
+
         // Test owner execute (should succeed)
         vm.prank(owner);
         paymasterInstance.execute(destination, value, data);
-        
-        assertEq(destination.balance, value, "Destination should receive value");
+
+        assertEq(
+            destination.balance,
+            value,
+            "Destination should receive value"
+        );
     }
 
     /**
      * @notice Tests invalid data length in paymaster data
      */
     function testInvalidDataLength() public {
-        vm.skip(true); // Skip until fix validatePaymasterUserOp
+        // Remove skip now that validatePaymasterUserOp is fixed
+        // vm.skip(true);
+
         UserOperation memory userOp = _createBasicUserOp();
         userOp.paymasterAndData = abi.encodePacked(address(paymasterInstance)); // Invalid length
 
         vm.prank(ENTRY_POINT);
         vm.expectRevert(ChatterPayPaymaster__InvalidDataLength.selector);
+        paymasterInstance.validatePaymasterUserOp(userOp, bytes32(0), 0);
+    }
+
+    /**
+     * @notice Tests validation with correct length but invalid format
+     */
+    function testValidDataLengthButInvalidFormat() public {
+        UserOperation memory userOp = _createBasicUserOp();
+
+        // Create data with correct length (93 bytes) but invalid content
+        bytes memory invalidData = new bytes(93);
+        for (uint i = 0; i < 93; i++) {
+            invalidData[i] = bytes1(uint8(i)); // Fill with sequential values
+        }
+
+        userOp.paymasterAndData = invalidData;
+
+        vm.prank(ENTRY_POINT);
+        // This should fail during signature verification
+        vm.expectRevert(); // Will likely revert with one of several possible errors
         paymasterInstance.validatePaymasterUserOp(userOp, bytes32(0), 0);
     }
 
@@ -200,19 +227,20 @@ contract PaymasterTest is BaseTest {
 
     /// @notice Creates a basic UserOperation for testing
     function _createBasicUserOp() internal view returns (UserOperation memory) {
-        return UserOperation({
-            sender: testWallet,
-            nonce: 0,
-            initCode: bytes(""),
-            callData: abi.encodeWithSignature("test()"),
-            callGasLimit: 1000000,
-            verificationGasLimit: 1000000,
-            preVerificationGas: 21000,
-            maxFeePerGas: 100 gwei,
-            maxPriorityFeePerGas: 100 gwei,
-            paymasterAndData: bytes(""),
-            signature: bytes("")
-        });
+        return
+            UserOperation({
+                sender: testWallet,
+                nonce: 0,
+                initCode: bytes(""),
+                callData: abi.encodeWithSignature("test()"),
+                callGasLimit: 1000000,
+                verificationGasLimit: 1000000,
+                preVerificationGas: 21000,
+                maxFeePerGas: 100 gwei,
+                maxPriorityFeePerGas: 100 gwei,
+                paymasterAndData: bytes(""),
+                signature: bytes("")
+            });
     }
 
     /// @notice Generates paymaster data including signature
@@ -228,21 +256,31 @@ contract PaymasterTest is BaseTest {
             abi.encode(
                 sender,
                 expiration,
-                block.chainid,
+                uint256(block.chainid),
                 ENTRY_POINT,
                 callData
             )
         );
-        
+
         // Sign message
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, messageHash);
+
+        // Solidity and JavaScript handle signature formats differently
+        // vm.sign produces a signature where the v value must be adjusted to be compatible
+        // with how our contract processes signatures
+        v = v + 27; // Adjust v value to match the 27/28 values expected by the contract
+
         bytes memory signature = abi.encodePacked(r, s, v);
-        
-        // Construct paymaster data
-        return abi.encodePacked(
-            paymaster,
-            signature,
-            bytes8(expiration)
-        );
+
+        // Ensure signature is exactly 65 bytes
+        require(signature.length == 65, "Signature must be 65 bytes");
+
+        // Construct paymaster data (20 + 65 + 8 = 93 bytes total)
+        return
+            abi.encodePacked(
+                paymaster, // 20 bytes
+                signature, // 65 bytes
+                bytes8(expiration) // 8 bytes
+            );
     }
 }

--- a/test/modules/SwapModule.t.sol
+++ b/test/modules/SwapModule.t.sol
@@ -181,6 +181,12 @@ contract SwapModule is BaseTest {
         console.log("Fee admin:", feeAdmin);
         console.log("Initial balance:", initialFeeAdminBalance);
 
+        // Approve router to spend USDC
+        address router = address(moduleWallet.getSwapRouter());
+        vm.startPrank(moduleWalletAddress); // La wallet misma debe hacer el approve
+        IERC20(USDC).approve(router, amountIn);
+        vm.stopPrank();
+
         // Execute swap
         vm.prank(ENTRY_POINT);
         moduleWallet.executeSwap(USDC, USDT, amountIn, minAmountOut, owner);

--- a/test/modules/SwapModule.t.sol
+++ b/test/modules/SwapModule.t.sol
@@ -17,12 +17,17 @@ import {IUniswapV3Factory, IUniswapV3Pool, INonfungiblePositionManager} from "..
 contract SwapModule is BaseTest {
     /// @notice Instance of the ChatterPay wallet being tested
     ChatterPay public moduleWallet;
-    
+
     /// @notice Address of the deployed wallet instance
     address public moduleWalletAddress;
 
     /// @notice Events emitted during swap operations
-    event SwapExecuted(address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut);
+    event SwapExecuted(
+        address indexed tokenIn,
+        address indexed tokenOut,
+        uint256 amountIn,
+        uint256 amountOut
+    );
     event LiquidityAdded(address pool, uint256 tokenId, uint128 liquidity);
 
     /// @notice Sets up the test environment
@@ -30,19 +35,22 @@ contract SwapModule is BaseTest {
     function setUp() public override {
         // Call parent setup first
         super.setUp();
-        
+
         // Deploy wallet using parent factory
         vm.startPrank(owner);
         moduleWalletAddress = factory.createProxy(owner);
         moduleWallet = ChatterPay(payable(moduleWalletAddress));
 
         // Verify router configuration
-        require(address(moduleWallet.getSwapRouter()) != address(0), "Router not set");
+        require(
+            address(moduleWallet.getSwapRouter()) != address(0),
+            "Router not set"
+        );
 
         // Setup tokens using parent contract constants
         moduleWallet.setTokenWhitelistAndPriceFeed(USDC, true, USDC_USD_FEED);
         moduleWallet.setTokenWhitelistAndPriceFeed(USDT, true, USDT_USD_FEED);
-        
+
         vm.stopPrank();
     }
 
@@ -58,49 +66,54 @@ contract SwapModule is BaseTest {
      */
     function testBasicSwap() public {
         uint256 SWAP_AMOUNT = 1000e6;
-        
+
         // Log initial setup
         console.log("=== Test Setup ===");
         console.log("Swap amount:", SWAP_AMOUNT);
         console.log("USDC address:", USDC);
         console.log("USDT address:", USDT);
-        
+
         // Get pool
-        address pool = IUniswapV3Factory(UNISWAP_FACTORY).getPool(USDC, USDT, POOL_FEE);
+        address pool = IUniswapV3Factory(UNISWAP_FACTORY).getPool(
+            USDC,
+            USDT,
+            POOL_FEE
+        );
         require(pool != address(0), "Pool doesn't exist");
         console.log("Pool address:", pool);
-        
+
         // Fund wallet
         _fundWallet(moduleWalletAddress, SWAP_AMOUNT);
         console.log("Wallet funded with:", SWAP_AMOUNT);
-        
+
         // Verify initial balance
         uint256 initialBalance = IERC20(USDC).balanceOf(moduleWalletAddress);
         console.log("Initial wallet balance:", initialBalance);
         require(initialBalance == SWAP_AMOUNT, "Funding failed");
-        
+
         uint256 initialUSDTBalance = IERC20(USDT).balanceOf(owner);
         console.log("Initial owner USDT balance:", initialUSDTBalance);
-        
+
         // Calculate expected fee
         uint256 expectedFee = _calculateExpectedFee(USDC, 50);
         console.log("Expected fee:", expectedFee);
-        
+
         // Calculate minimum amount out
-        uint256 minAmountOut = ((SWAP_AMOUNT - expectedFee) * 10**12) * 30 / 100;
+        uint256 minAmountOut = (((SWAP_AMOUNT - expectedFee) * 10 ** 12) * 30) /
+            100;
         console.log("Minimum amount out:", minAmountOut);
-        
+
         vm.startPrank(ENTRY_POINT);
         moduleWallet.approveToken(USDC, SWAP_AMOUNT);
         console.log("Token approved for swap");
-        
+
         moduleWallet.executeSwap(USDC, USDT, SWAP_AMOUNT, minAmountOut, owner);
         vm.stopPrank();
-        
+
         uint256 finalUSDTBalance = IERC20(USDT).balanceOf(owner);
         console.log("Final owner USDT balance:", finalUSDTBalance);
         console.log("USDT received:", finalUSDTBalance - initialUSDTBalance);
-        
+
         assertTrue(finalUSDTBalance > initialUSDTBalance);
     }
 
@@ -116,15 +129,19 @@ contract SwapModule is BaseTest {
 
         uint256 amountIn = 1000e6;
         uint256 minOut = 990e6;
-        
+
         _fundWallet(moduleWalletAddress, amountIn);
-        
+
         vm.startPrank(ENTRY_POINT);
         moduleWallet.approveToken(USDC, amountIn);
         moduleWallet.executeSwap(USDC, USDT, amountIn, minOut, owner);
         vm.stopPrank();
-        
-        assertGt(IERC20(USDT).balanceOf(owner), 0, "Swap with custom fee failed");
+
+        assertGt(
+            IERC20(USDT).balanceOf(owner),
+            0,
+            "Swap with custom fee failed"
+        );
     }
 
     /**
@@ -139,9 +156,9 @@ contract SwapModule is BaseTest {
 
         uint256 amountIn = 1000e6;
         uint256 minOut = 990e6;
-        
+
         _fundWallet(moduleWalletAddress, amountIn);
-        
+
         vm.startPrank(ENTRY_POINT);
         moduleWallet.approveToken(USDC, amountIn);
         moduleWallet.executeSwap(USDC, USDT, amountIn, minOut, owner);
@@ -154,11 +171,11 @@ contract SwapModule is BaseTest {
      */
     function testSwapWithFee() public {
         uint256 amountIn = 1000e6;
-        
+
         _fundWallet(moduleWalletAddress, amountIn);
         address feeAdmin = moduleWallet.getFeeAdmin();
         uint256 minAmountOut = 0; // Set minimum amount for testing purposes
-        
+
         // Get initial balances
         uint256 initialFeeAdminBalance = IERC20(USDC).balanceOf(feeAdmin);
         console.log("Fee admin:", feeAdmin);
@@ -177,28 +194,29 @@ contract SwapModule is BaseTest {
         // Calculate expected fee and check within margin
         uint256 expectedFee = _calculateExpectedFee(USDC, 50);
         console.log("Expected fee:", expectedFee);
-        
+
         uint256 tolerance = (expectedFee * 1) / 100; // tolerance: 1%
         assertTrue(
-            feeCollected >= expectedFee - tolerance && feeCollected <= expectedFee + tolerance,
+            feeCollected >= expectedFee - tolerance &&
+                feeCollected <= expectedFee + tolerance,
             "Fee not within acceptable range (1%)"
         );
     }
 
     /**
-     * @notice Tests swap failure scenarios
+     * @notice Tests that swaps fail with non-whitelisted tokens
      * @dev Attempts swap with non-whitelisted token to verify proper error handling
      */
-    function testFailInvalidSwap() public {
+    function test_RevertWhen_TokenNotWhitelisted() public {
         uint256 amountIn = 1000e6;
         _fundWallet(moduleWalletAddress, amountIn);
-        
+
         vm.startPrank(owner);
-        moduleWallet.setTokenWhitelistAndPriceFeed(USDC, false, address(0));
+        moduleWallet.setTokenWhitelistAndPriceFeed(USDC, false, USDC_USD_FEED);
         vm.stopPrank();
-        
+
         vm.prank(ENTRY_POINT);
-        vm.expectRevert("ChatterPay__TokenNotWhitelisted");
+        vm.expectRevert(bytes4(keccak256("ChatterPay__TokenNotWhitelisted()")));
         moduleWallet.executeSwap(USDC, USDT, amountIn, 0, owner);
     }
 
@@ -211,20 +229,23 @@ contract SwapModule is BaseTest {
         vm.warp(1737341661);
 
         // Setup swap parameters
-        uint256 amountIn = 1000e6; 
+        uint256 amountIn = 1000e6;
         uint256 fee = 5e5; // 0.5 cents in USDC
         uint256 swapAmount = amountIn - fee;
-        uint256 minOut = (swapAmount * 1e12) * 7 / 10;
+        uint256 minOut = ((swapAmount * 1e12) * 7) / 10;
 
         // Log initial state
         _logSwapState("Initial State", moduleWalletAddress);
-        
+
         // Fund wallet
         _fundWallet(moduleWalletAddress, amountIn);
-        
+
         // Verify funding
         _logSwapState("After Funding", moduleWalletAddress);
-        require(IERC20(USDC).balanceOf(moduleWalletAddress) == amountIn, "Funding failed");
+        require(
+            IERC20(USDC).balanceOf(moduleWalletAddress) == amountIn,
+            "Funding failed"
+        );
 
         // Log router info
         _logRouterInfo(moduleWalletAddress);
@@ -258,19 +279,19 @@ contract SwapModule is BaseTest {
         uint256 feeInCents
     ) internal view returns (uint256) {
         uint256 tokenDecimals = IERC20Extended(token).decimals();
-        
+
         console.log("=== Fee Calculation Debug ===");
         console.log("Token:", token);
         console.log("Fee in cents:", feeInCents);
         console.log("Token decimals:", tokenDecimals);
-        
+
         // Calculate step by step
         uint256 scaledAmount = feeInCents * (10 ** tokenDecimals);
         console.log("Scaled amount:", scaledAmount);
-        
+
         uint256 finalFee = scaledAmount / 100;
         console.log("Final fee:", finalFee);
-        
+
         return finalFee;
     }
 }


### PR DESCRIPTION
## Changelog
- Adapted paymaster code to properly validate the txs
- Updated paymaster test
- Removed block timestamp approach due to error: -32502 Opcode Violation (see resources)
- Fixed swap tests

## Resources
- Opcode rules: https://docs.stackup.sh/docs/opcode-rules
- Deployed paymaster in Arbitrum Sepolia `0x18caa97e9d9f50e2381eb96e1ec762ee022cc050`
- Successful transfer: https://sepolia.arbiscan.io/tx/0x876c0df48827b1dfbbc07bfa4e4969919c87d11d83e2c0c35f6895d1194211b7
- Successful swap:
https://sepolia.arbiscan.io/tx/0x4c4471108c198b481c82393f4f4b1dc8270921e77b7d2d3f7e57093a8905e862

---

## Close:

- #76 