### PR TITLE
[refactor] :hammer: document intentional success ignore in _payPrefun…

### DIFF
--- a/src/ChatterPay.sol
+++ b/src/ChatterPay.sol
@@ -704,13 +704,18 @@ contract ChatterPay is
     }
 
     /**
-     * @dev Handles account prefunding
-     * @param missingAccountFunds Amount of funds to prefund
+     * @dev Handles account prefunding by sending ETH to the EntryPoint (msg.sender).
+     * The success of the transfer is intentionally not enforced, as the EntryPoint
+     * itself is responsible for validating whether it received sufficient funds.
+     * Reverting here could interfere with bundler simulation and ERC-4337 flow,
+     * so failures are ignored by design.
+     * @param missingAccountFunds The minimum amount of ETH to send to the EntryPoint.
      */
     function _payPrefund(uint256 missingAccountFunds) internal {
         if (missingAccountFunds != 0) {
             (bool success,) = payable(msg.sender).call{value: missingAccountFunds, gas: type(uint256).max}("");
-            (success);
+            // Intentionally ignoring success — EntryPoint validates received funds
+            success;
         }
     }
 


### PR DESCRIPTION
### Summary
This PR improves the handling of the _payPrefund function to better align with the ERC-4337 specification.

### Changes
* Updated _payPrefund to explicitly ignore the result of the call to msg.sender, clarifying that any failure is intentionally not enforced.
* Added a detailed doc comment explaining why the transfer result is not required to succeed, referencing ERC-4337 behavior.
* Ensured the code avoids unused variable warnings without introducing unnecessary reverts.

### Rationale
In the ERC-4337 flow, it's the EntryPoint contract's responsibility to validate whether sufficient funds were received. Failing or reverting from _payPrefund could interfere with bundler simulation and user operation processing. This change makes the intention explicit and maintains full compatibility with the spec.

### Closes

- #101 