### PR TITLE
merge fix/low-medium-value into develop

### DIFF
--- a/src/ChatterPay.sol
+++ b/src/ChatterPay.sol
@@ -113,7 +113,7 @@ contract ChatterPay is
 
     // Uniswap pool fees
     uint24 public constant POOL_FEE_LOW = 3000; // 0.3%
-    uint24 public constant POOL_FEE_MEDIUM = 3000; // 0.3%
+    uint24 public constant POOL_FEE_MEDIUM = 5000; // 0.5%
     uint24 public constant POOL_FEE_HIGH = 10000; // 1%
 
     // Default slippage values (in basis points, 1 bp = 0.01%)


### PR DESCRIPTION
### Changes:

- Corrected the value of POOL_FEE_MEDIUM, which was mistakenly set to the same value as POOL_FEE_LOW. This resolves a potential copy-paste error and ensures distinct fee tiers for swap operations.

### Details:

- [fix] :bug: correct pool_fee_medium value 

### Related to:

- #109