### PR TITLE
merge fix/revert-pool-fee-medium into develop

### DIFF
--- a/src/ChatterPay.sol
+++ b/src/ChatterPay.sol
@@ -113,7 +113,7 @@ contract ChatterPay is
 
     // Uniswap pool fees
     uint24 public constant POOL_FEE_LOW = 3000; // 0.3%
-    uint24 public constant POOL_FEE_MEDIUM = 5000; // 0.5%
+    uint24 public constant POOL_FEE_MEDIUM = 3000; // 0.3%
     uint24 public constant POOL_FEE_HIGH = 10000; // 1%
 
     // Default slippage values (in basis points, 1 bp = 0.01%)


### PR DESCRIPTION
### Changes:
- Reverting the change to POOL_FEE_MEDIUM from 5000 back to 3000 because the updated value caused backend swap failures. The error indicates the transaction could not be executed or found, likely due to 5000 not being a valid UniswapV3 pool fee tier for the token pair in use. Restoring the original value to ensure swaps work as expected.


### Details:

- [revert] ⏪ revert update of poo_fee_medium

### Related To:

- #109