### PR TITLE
merge feature/92 into feature/20250420

### DIFF
--- a/script/DeployAllContracts.s.sol
+++ b/script/DeployAllContracts.s.sol
@@ -144,7 +144,6 @@ contract DeployAllContracts is Script {
             config.backendSigner, // _owner
             address(paymaster), // _paymaster
             uniswapRouter, // _router
-            config.backendSigner, // _feeAdmin (using account as fee admin)
             tokens, // _whitelistedTokens
             priceFeeds, // _priceFeeds
             tokensStableFlags
@@ -160,20 +159,16 @@ contract DeployAllContracts is Script {
      * @notice Deploys the ChatterPay contract using UUPS Proxy with new initializer parameters.
      */
     function deployChatterPay() internal {
-        // Use config.backendSigner as fee admin (must equal factory.owner())
-        address feeAdmin = config.backendSigner;
-
         // Deploy the ChatterPay contract using UUPS Proxy via Upgrades library.
         address proxy = Upgrades.deployUUPSProxy(
             "ChatterPay.sol:ChatterPay", // Contract name as string.
             abi.encodeWithSignature(
-                "initialize(address,address,address,address,address,address,address[],address[],bool[])",
+                "initialize(address,address,address,address,address,address[],address[],bool[])",
                 config.entryPoint, // _entryPoint.
                 config.backendSigner, // _owner (owner must be the creator).
                 address(paymaster), // _paymaster.
                 uniswapRouter, // _router.
                 address(factory), // _factory.
-                feeAdmin, // _feeAdmin.
                 tokens, // _whitelistedTokens (token addresses).
                 priceFeeds, // _priceFeeds (corresponding price feed addresses).
                 tokensStableFlags // __tokensStableFlags.

--- a/script/DeployFactory.s.sol
+++ b/script/DeployFactory.s.sol
@@ -39,7 +39,6 @@ contract DeployFactory is Script {
             config.backendSigner, // _owner
             vm.envAddress("PAYMASTER_ADDRESS"), // _paymaster
             config.uniswapConfig.router, // _router
-            config.backendSigner, // _feeAdmin (using account as fee admin)
             tokens, // _whitelistedTokens
             priceFeeds, // _priceFeeds
             tokensStableFlags

--- a/src/ChatterPay.sol
+++ b/src/ChatterPay.sol
@@ -266,6 +266,10 @@ contract ChatterPay is
         }
     }
 
+    function getChatterPayOwner() public view returns (address) {
+        return s_state.factory.owner();
+    }
+
     function getFeeInCents() public view returns (uint256) {
         return s_state.feeInCents;
     }
@@ -776,7 +780,7 @@ contract ChatterPay is
      * @dev Function that authorizes an upgrade to a new implementation
      * @param newImplementation Address of the new implementation
      */
-    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+    function _authorizeUpgrade(address newImplementation) internal override onlyChatterPayAdmin {}
 
     receive() external payable {}
 }

--- a/src/ChatterPay.sol
+++ b/src/ChatterPay.sol
@@ -24,7 +24,7 @@ import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Cont
 
 error ChatterPay__NotFromEntryPoint();
 error ChatterPay__NotFromEntryPointOrOwner();
-error ChatterPay__NotFromFactoryOwner();
+error ChatterPay__NotFromChatterPayAdmin();
 error ChatterPay__ExecuteCallFailed(bytes);
 error ChatterPay__PriceFeedNotSet();
 error ChatterPay__InvalidPrice();
@@ -133,9 +133,9 @@ contract ChatterPay is
                                MODIFIERS
     //////////////////////////////////////////////////////////////*/
 
-    modifier onlyFactoryOwner() {
+    modifier onlyChatterPayAdmin() {
         if (msg.sender != s_state.factory.owner()) {
-            revert ChatterPay__NotFromFactoryOwner();
+            revert ChatterPay__NotFromChatterPayAdmin();
         }
         _;
     }
@@ -155,6 +155,7 @@ contract ChatterPay is
     }
 
     /**
+     * ChatterPay__NotFromChatterPayAdmin
      * @dev Disables initialization for the implementation contract
      */
 
@@ -491,7 +492,7 @@ contract ChatterPay is
      * @param value ETH value to send
      * @param func Function call data
      */
-    function execute(address dest, uint256 value, bytes calldata func) external onlyFactoryOwner nonReentrant {
+    function execute(address dest, uint256 value, bytes calldata func) external onlyChatterPayAdmin nonReentrant {
         if (dest == address(this)) revert ChatterPay__InvalidTarget();
         (bool success, bytes memory result) = dest.call{value: value}(func);
         if (!success) revert ChatterPay__ExecuteCallFailed(result);
@@ -530,7 +531,7 @@ contract ChatterPay is
      * @notice Updates the fee amount
      * @param _newFeeInCents New fee in cents
      */
-    function updateFee(uint256 _newFeeInCents) external onlyOwner {
+    function updateFee(uint256 _newFeeInCents) external onlyChatterPayAdmin {
         if (_newFeeInCents > s_state.maxFeeInCents) {
             revert ChatterPay__ExceedsMaxFee();
         }

--- a/test/modules/AdminModule.t.sol
+++ b/test/modules/AdminModule.t.sol
@@ -21,7 +21,6 @@ contract AdminModule is BaseTest {
     event FeeUpdated(uint256 oldFee, uint256 newFee);
     event TokenWhitelisted(address indexed token, bool status);
     event PriceFeedUpdated(address indexed token, address indexed priceFeed);
-    event FeeAdminUpdated(address indexed oldAdmin, address indexed newAdmin);
     event CustomPoolFeeSet(address indexed tokenA, address indexed tokenB, uint24 fee);
     event CustomSlippageSet(address indexed token, uint256 slippageBps);
 

--- a/test/modules/SwapModule.t.sol
+++ b/test/modules/SwapModule.t.sol
@@ -157,17 +157,16 @@ contract SwapModule is BaseTest {
         uint256 amountIn = 1000e6;
 
         _fundWallet(moduleWalletAddress, amountIn);
-        address feeAdmin = moduleWallet.getFeeAdmin();
         uint256 minAmountOut = 0; // Set minimum amount for testing purposes
 
         // Get initial balances
-        uint256 initialFeeAdminBalance = IERC20(USDC).balanceOf(feeAdmin);
-        console.log("Fee admin:", feeAdmin);
-        console.log("Initial balance:", initialFeeAdminBalance);
+        uint256 initialOwnerBalance = IERC20(USDC).balanceOf(owner);
+        console.log("admin:", owner);
+        console.log("Initial balance:", initialOwnerBalance);
 
         // Approve router to spend USDC
         address router = address(moduleWallet.getSwapRouter());
-        vm.startPrank(moduleWalletAddress); // La wallet misma debe hacer el approve
+        vm.startPrank(moduleWalletAddress);
         IERC20(USDC).approve(router, amountIn);
         vm.stopPrank();
 
@@ -176,9 +175,9 @@ contract SwapModule is BaseTest {
         moduleWallet.executeSwap(USDC, USDT, amountIn, minAmountOut, owner);
 
         // Get final balance
-        uint256 finalFeeAdminBalance = IERC20(USDC).balanceOf(feeAdmin);
-        console.log("Final balance:", finalFeeAdminBalance);
-        uint256 feeCollected = finalFeeAdminBalance - initialFeeAdminBalance;
+        uint256 finalOwnerBalance = IERC20(USDC).balanceOf(owner);
+        console.log("Final balance:", finalOwnerBalance);
+        uint256 feeCollected = finalOwnerBalance - initialOwnerBalance;
         console.log("Fee collected:", feeCollected);
 
         // Calculate expected fee and check within margin

--- a/test/modules/TransferModule.t.sol
+++ b/test/modules/TransferModule.t.sol
@@ -64,8 +64,7 @@ contract TransferModule is BaseTest {
         uint256 totalAmount = 600e6 + (EXPECTED_FEE * 3);
         _fundWallet(walletAddress, totalAmount);
 
-        address feeAdmin = walletInstance.getFeeAdmin();
-        uint256 initialFeeBalance = IERC20(USDC).balanceOf(feeAdmin);
+        uint256 initialFeeBalance = IERC20(USDC).balanceOf(owner);
 
         address[] memory recipients = new address[](3);
         recipients[0] = makeAddr("recipient1");
@@ -85,7 +84,7 @@ contract TransferModule is BaseTest {
         vm.prank(ENTRY_POINT);
         walletInstance.executeBatchTokenTransfer(tokens, recipients, amounts);
 
-        uint256 finalFeeBalance = IERC20(USDC).balanceOf(feeAdmin);
+        uint256 finalFeeBalance = IERC20(USDC).balanceOf(owner);
         uint256 feesCollected = finalFeeBalance - initialFeeBalance;
         assertApproxEqAbs(feesCollected, EXPECTED_FEE * 3, FEE_TOLERANCE * 3, "Incorrect fees collected");
     }
@@ -151,13 +150,13 @@ contract TransferModule is BaseTest {
             // Fund wallet
             _fundWallet(walletAddress, testAmounts[i]);
 
-            uint256 initialFeeAdminBalance = IERC20(USDC).balanceOf(walletInstance.getFeeAdmin());
+            uint256 initialOwnerBalance = IERC20(USDC).balanceOf(owner);
 
             // Execute transfer
             vm.prank(ENTRY_POINT);
             walletInstance.executeTokenTransfer(USDC, user, testAmounts[i]);
 
-            uint256 feeCollected = IERC20(USDC).balanceOf(walletInstance.getFeeAdmin()) - initialFeeAdminBalance;
+            uint256 feeCollected = IERC20(USDC).balanceOf(owner) - initialOwnerBalance;
             assertApproxEqAbs(feeCollected, EXPECTED_FEE, FEE_TOLERANCE, "Incorrect fee amount collected");
         }
     }
@@ -170,7 +169,7 @@ contract TransferModule is BaseTest {
         _fundWallet(walletAddress, 1000e6); // 1000 USDC
 
         // Get initial balances
-        uint256 initialFeeAdminBalance = IERC20(USDC).balanceOf(walletInstance.getFeeAdmin());
+        uint256 initialOwnerBalance = IERC20(USDC).balanceOf(owner);
         uint256 initialRecipientBalance = IERC20(USDC).balanceOf(user);
 
         // Execute transfer
@@ -182,10 +181,7 @@ contract TransferModule is BaseTest {
 
         // Verify fee was taken
         assertApproxEqAbs(
-            IERC20(USDC).balanceOf(walletInstance.getFeeAdmin()) - initialFeeAdminBalance,
-            fee,
-            FEE_TOLERANCE,
-            "Fee not transferred correctly"
+            IERC20(USDC).balanceOf(owner) - initialOwnerBalance, fee, FEE_TOLERANCE, "Fee not transferred correctly"
         );
 
         // Verify recipient received correct amount

--- a/test/setup/BaseTest.sol
+++ b/test/setup/BaseTest.sol
@@ -139,7 +139,6 @@ abstract contract BaseTest is Test {
             owner, // _owner
             address(paymaster), // _paymaster
             UNISWAP_ROUTER, // _router
-            owner, // _feeAdmin
             new address[](0), // _whitelistedTokens
             new address[](0), // _priceFeeds
             new bool[](0) // _tokensStableFlags


### PR DESCRIPTION
### Changes:

-  Refactored the access control of critical admin functions in the `ChatterPay` contract by restricting both the `upgradeToAndCall` and `updateFee` functions to the ChatterPay admin (`onlyChatterPayAdmin`), improving security and centralizing permission management. It also added a new `getChatterPayOwner` view function to retrieve the admin address from the factory. The corresponding tests were updated to reflect the new access control logic, ensuring that only the designated admin is authorized to perform sensitive operations.

### Details:

- [refactor] 🔒 restrict upgrade and fee update to chatterpay admin (#92)
- [feat] ✨ add getChatterPayOwner function (#92)
- [test] 🧪 update admin tests to reflect new ChatterPay admin access control (#92)

### Closes:

- #92

