### PR TITLE
merge release/20250512 into main

### DIFF
--- a/.doc/deployment/deployment-guidelines.md
+++ b/.doc/deployment/deployment-guidelines.md
@@ -9,7 +9,9 @@ Find contracts deployment addresses by network at these links:
 - WETH:  [Arbitrum Contract Addresses](https://docs.arbitrum.io/build-decentralized-apps/reference/contract-addresses)
 - Circle: [USDC TOken Addresses](https://developers.circle.com/stablecoins/usdc-on-test-networks)
 - EntryPoint: [eth Infinitism - Account Abstraction](https://github.com/eth-infinitism/account-abstraction/releases/tag/v0.6.0)
-- Uniswap: [Uniswap Contract Deployments](https://docs.uniswap.org/contracts/v3/reference/deployments/) 
+- Uniswap: 
+   - [Uniswap Contract Deployments](https://docs.uniswap.org/contracts/v3/reference/deployments/)
+   - [Official Uniswap v3 Deployments List](https://gov.uniswap.org/t/official-uniswap-v3-deployments-list/24323/3) 
 - Chainlink: [Price FeedsContract Addresses](https://docs.chain.link/data-feeds/price-feeds/addresses)
 - Scroll: [Scroll Contract Addresses](https://docs.scroll.io/es/developers/scroll-contracts/)
 

--- a/script/utils/HelperConfig.s.sol
+++ b/script/utils/HelperConfig.s.sol
@@ -269,10 +269,10 @@ contract HelperConfig is Script {
      * @return NetworkConfig Configuration with Scroll addresses
      */
     function getScrollConfig() public view returns (NetworkConfig memory) {
-        TokenConfig[] memory tokenConfigs = new TokenConfig[](3);
+        TokenConfig[] memory tokenConfigs = new TokenConfig[](5);
 
         tokenConfigs[0] = TokenConfig({
-            symbol: "UDST",
+            symbol: "USDT",
             token: 0xf55BEC9cafDbE8730f096Aa55dad6D22d44099Df,
             priceFeed: 0xf376A91Ae078927eb3686D6010a6f1482424954E,
             isStable: true
@@ -292,12 +292,30 @@ contract HelperConfig is Script {
             isStable: true
         });
 
+        tokenConfigs[3] = TokenConfig({
+            symbol: "WBTC",
+            token: 0x3C1BCa5a656e69edCD0D4E36BEbb3FcDAcA60Cf1,
+            priceFeed: 0x61C432B58A43516899d8dF33A5F57edb8d57EB77,
+            isStable: false
+        });
+
+        tokenConfigs[4] = TokenConfig({
+            symbol: "SCR",
+            token: 0xd29687c813D741E2F938F4aC377128810E217b1b,
+            priceFeed: 0x26f6F7C468EE309115d19Aa2055db5A74F8cE7A5,
+            isStable: false
+        });
+
         return NetworkConfig({
             entryPoint: 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789,
             backendSigner: BACKEND_SIGNER,
             nftBaseUri: "https://back.chatterpay.net/nft/metadata/opensea/",
             tokensConfig: tokenConfigs,
-            uniswapConfig: UniswapConfig({router: address(0), factory: address(0), positionManager: address(0)})
+            uniswapConfig: UniswapConfig({
+                router: 0x595E7160858b1AdA94Bda790D8699C85e595117E,
+                factory: 0x70C62C8b8e801124A4Aa81ce07b637A3e83cb919,
+                positionManager: 0xB39002E4033b162fAc607fc3471E205FA2aE5967
+            })
         });
     }
 

--- a/src/ChatterPay.sol
+++ b/src/ChatterPay.sol
@@ -259,7 +259,7 @@ contract ChatterPay is
         _getChatterPayState().paymaster = _paymaster;
         _getChatterPayState().swapRouter = ISwapRouter(_router);
         _getChatterPayState().factory = IChatterPayWalletFactory(_factory);
-        _getChatterPayState().feeInCents = 50; // Default fee in cents
+        _getChatterPayState().feeInCents = 20; // Default fee in cents
 
         _getChatterPayState().uniswapPoolFeeLow = 500; // 0.05%
         _getChatterPayState().uniswapPoolFeeMedium = 3000; // 0.3%

--- a/test/modules/AdminModule.t.sol
+++ b/test/modules/AdminModule.t.sol
@@ -42,6 +42,7 @@ contract AdminModule is BaseTest {
         walletInstance.setTokenWhitelistAndPriceFeed(USDT, true, USDT_USD_FEED);
         walletInstance.addStableToken(USDC);
         walletInstance.addStableToken(USDT);
+        walletInstance.updateFee(50);
         vm.stopPrank();
     }
 

--- a/test/modules/SwapModule.t.sol
+++ b/test/modules/SwapModule.t.sol
@@ -50,6 +50,7 @@ contract SwapModule is BaseTest {
         moduleWallet.setTokenWhitelistAndPriceFeed(USDT, true, USDT_USD_FEED);
         moduleWallet.addStableToken(USDC);
         moduleWallet.addStableToken(USDT);
+        moduleWallet.updateFee(50);
 
         vm.stopPrank();
     }

--- a/test/modules/TransferModule.t.sol
+++ b/test/modules/TransferModule.t.sol
@@ -35,6 +35,7 @@ contract TransferModule is BaseTest {
         walletInstance.setTokenWhitelistAndPriceFeed(USDT, true, USDT_USD_FEED);
         walletInstance.addStableToken(USDC);
         walletInstance.addStableToken(USDT);
+        walletInstance.updateFee(50);
 
         // Disable freshness check for price feeds in tests
         walletInstance.updatePriceConfig(1 days, 8);


### PR DESCRIPTION
### Chnages:

- Reduced the default fee applied to token operations from 50 cents to 20 cents. The change was intended to make transactions more affordable for users while maintaining sustainability for the protocol. This update was part of ongoing efforts to optimize cost-efficiency and enhance the user experience. 
- Added Uniswap mainnet addresses and expanded the Scroll token list with WBTC and SCR, both non-stable and linked to Chainlink feeds. 

### Related to:

- #157
- #158