### PR TITLE
merge feature/20250607 into develop

### DIFF
--- a/src/ChatterPay.sol
+++ b/src/ChatterPay.sol
@@ -152,6 +152,7 @@ contract ChatterPay is
         address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, address recipient
     );
     event FeeUpdated(uint256 indexed oldFee, uint256 indexed newFee);
+    event FeeTransferred(address indexed from, address indexed to, address indexed token, uint256 amount);
     event TokenWhitelisted(address indexed token, bool indexed status);
     event PriceFeedUpdated(address indexed token, address indexed priceFeed);
     event CustomPoolFeeSet(address indexed tokenA, address indexed tokenB, uint24 fee);
@@ -898,12 +899,14 @@ contract ChatterPay is
     }
 
     /**
-     * @dev Transfers fee to owner
+     * @dev Transfers fee to chatterPay owner
      * @param token Token address to transfer
      * @param amount Amount to transfer
      */
     function _transferFee(address token, uint256 amount) internal {
-        IERC20(token).safeTransfer(owner(), amount);
+        address chatterPayOwner = getChatterPayOwner();
+        IERC20(token).safeTransfer(chatterPayOwner, amount);
+        emit FeeTransferred(address(this), chatterPayOwner, token, amount);
     }
 
     /**

--- a/test/setup/BaseTest.sol
+++ b/test/setup/BaseTest.sol
@@ -64,9 +64,6 @@ abstract contract BaseTest is Test {
                         STATE VARIABLES
     //////////////////////////////////////////////////////////////*/
 
-    // network to test
-    uint256 chainId = 421614;
-
     // Core contract instances
     ChatterPay public implementation;
     ChatterPayWalletFactory public factory;
@@ -100,7 +97,7 @@ abstract contract BaseTest is Test {
      */
     function setUp() public virtual {
         // Load network-specific constants
-        BaseConstants.Config memory config = BaseConstants.getConfig(chainId);
+        BaseConstants.Config memory config = BaseConstants.getConfig(block.chainid);
         ENTRY_POINT = config.ENTRY_POINT;
         UNISWAP_ROUTER = config.UNISWAP_ROUTER;
         UNISWAP_FACTORY = config.UNISWAP_FACTORY;
@@ -135,7 +132,7 @@ abstract contract BaseTest is Test {
                         GETTERS FUNCTIONS
     //////////////////////////////////////////////////////////////*/
     function getUSDCAddress() public virtual returns (address) {
-        BaseConstants.Config memory config = BaseConstants.getConfig(chainId);
+        BaseConstants.Config memory config = BaseConstants.getConfig(block.chainid);
         return config.USDC;
     }
 


### PR DESCRIPTION
### Changes:

- Updated `_transferFee` to send the fee to the `ChatterPay` owner (retrieved via `getChatterPayOwner()`) instead of the generic `owner()`.
- Replaced hardcoded `chainId` with dynamic resolution using `block.chainid` in the test setup to allow environment-agnostic configuration.

### Closes:

- #166 
- #167

