### PR TITLE
merge feature/20260809 into dev

### DIFF
--- a/.doc/deployment/deployment-guidelines.md
+++ b/.doc/deployment/deployment-guidelines.md
@@ -38,7 +38,17 @@ cast send paymaster_contract_address "addStake(uint32)" 100000 --value 100000000
    - Make sure you have enough ETH in the backend signer wallet to cover the stake.
    - The staking process is required for security validation and interaction with the EntryPoint.
 
-2. **To check the balance and verify the stake:**
+2. **Deposit ETH so the Paymaster can actually pay for sponsored gas:**
+
+   `addStake` alone is not enough — it only covers the security stake, not the balance the Paymaster spends on sponsored UserOperations. Without a deposit, `getDepositInfo` will show `deposit=0` and every sponsored transaction will fail.
+
+```sh
+cast send entrypoint_contract_address "depositTo(address)" paymaster_contract_address --value 50000000000000000 --from backend_signer_wallet_address --rpc-url https://arb-sepolia.g.alchemy.com/v2/API_KEY_ALCHEMY --private-key _backend_signer_wallet_private_key
+```
+
+   - `50000000000000000` equals **0.05 ETH** deposited (adjust based on expected sponsored gas volume).
+
+3. **To check the balance and verify the stake and deposit:**
 
 ```sh
 cast call entrypoint_contract_address "getDepositInfo(address)(uint112,bool,uint112,uint32,uint48)" paymaster_contract_address --rpc-url https://arb-sepolia.g.alchemy.com/v2/API_KEY_ALCHEMY

--- a/example_env
+++ b/example_env
@@ -5,7 +5,7 @@
 
 # --- Network Configuration ---
 RPC_URL=https://rpc.scroll.io        # RPC endpoint for the target network
-CHAIN_ID=534351                      # Scroll Sepolia: 534351 | Scroll Mainnet: 534352
+CHAIN_ID=534351                      # Scroll Sepolia: 534351 | Scroll Mainnet: 534352 | Arbitrum Sepolia (dev/test): 421614
 DEPLOY_NETWORK_ENV=LOCAL             # LOCAL | TEST | PROD
 
 # --- Credentials ---

--- a/script/utils/HelperConfig.s.sol
+++ b/script/utils/HelperConfig.s.sol
@@ -187,7 +187,7 @@ contract HelperConfig is Script {
      * @return NetworkConfig Configuration with Scroll Sepolia addresses
      */
     function getScrollSepoliaConfig() public view returns (NetworkConfig memory) {
-        TokenConfig[] memory tokenConfigs = new TokenConfig[](4);
+        TokenConfig[] memory tokenConfigs = new TokenConfig[](9);
 
         tokenConfigs[0] = TokenConfig({
             symbol: "UDST",


### PR DESCRIPTION
## Changes

- Fixed an out-of-bounds array access in `HelperConfig.getScrollSepoliaConfig()` that broke contract deployment for every network, not only Scroll Sepolia, because `HelperConfig`'s constructor initializes all network configs unconditionally. Also deployed the full ChatterPay contract set to Arbitrum Sepolia (new dev/test network, replacing the now-dead Scroll Sepolia) and staked/deposited ETH for the Paymaster in the EntryPoint.

## Related To

- #193